### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -56,11 +56,11 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::c::external::brew()
+# Function: p6df::modules::c::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::c::external::brew() {
+p6df::modules::c::external::brews() {
 
   p6df::core::homebrew::cli::brew::install autoconf
   p6df::core::homebrew::cli::brew::install automake


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly