### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -69,3 +69,20 @@ p6df::modules::c::external::brews() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words c $CC = p6df::modules::c::prompt::system()
+#
+#  Returns:
+#	words - c $CC
+#
+#  Environment:	 CC
+#>
+######################################################################
+p6df::modules::c::prompt::system() {
+
+  p6_return_words 'c' '$CC'
+}
+

--- a/init.zsh
+++ b/init.zsh
@@ -83,6 +83,6 @@ p6df::modules::c::external::brews() {
 ######################################################################
 p6df::modules::c::prompt::system() {
 
-  p6_return_words 'c' '$CC'
+  p6_return_words 'c' "$"
 }
 


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None