### PR TITLE
refactor(module): remove unused prompt system function

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -69,20 +69,3 @@ p6df::modules::c::external::brews() {
 
   p6_return_void
 }
-
-######################################################################
-#<
-#
-# Function: words c $CC = p6df::modules::c::prompt::system()
-#
-#  Returns:
-#	words - c $CC
-#
-#  Environment:	 CC
-#>
-######################################################################
-p6df::modules::c::prompt::system() {
-
-  p6_return_words 'c' "$"
-}
-


### PR DESCRIPTION
## What
Remove the dead-code function `p6df::modules::c::prompt::system()` from `init.zsh`, which returned a placeholder `$` string with no actual value.

## Why
This function was an unused stub that returned a meaningless placeholder. Removing it reduces maintenance surface and avoids confusion.

## Test plan
- Reviewed diff manually
- No callers of this function exist in this module

## Dependencies
None